### PR TITLE
Don't use dirty backup area anymore

### DIFF
--- a/system_properties.cpp
+++ b/system_properties.cpp
@@ -311,10 +311,10 @@ int SystemProperties::Update(prop_info* pi, const char* value, unsigned int len)
   atomic_thread_fence(memory_order_release);
   serial |= 1;
   atomic_store_explicit(&pi->serial, serial, memory_order_relaxed);
-  strlcpy(pi->value, value, len + 1);
+  strncpy(pi->value, value, PROP_VALUE_MAX);
   if (have_override) {
     atomic_store_explicit(&override_pi->serial, serial, memory_order_relaxed);
-    strlcpy(override_pi->value, value, len + 1);
+    strncpy(override_pi->value, value, PROP_VALUE_MAX);
   }
   // Now the primary value property area is up-to-date. Let readers know that they should
   // look at the property value instead of the backup area.


### PR DESCRIPTION
https://github.com/topjohnwu/system_properties/commit/5804633f8cf3ac09157f6fd9fa77357cfe2c7866 The old patch is wrong, bit 0 should not be set, it will make init read the empty dirty backup area.